### PR TITLE
Decide last login update implementation

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\TracksLastLogin;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -15,6 +16,7 @@ class User extends Authenticatable
     use HasFactory;
     use Notifiable;
     use SoftDeletes;
+    use TracksLastLogin;
 
     /**
      * The table associated with the model.
@@ -40,6 +42,7 @@ class User extends Authenticatable
         'profile_picture_path',
         'address',
         'email_verified_at',
+        'last_login',
     ];
 
     /**
@@ -62,6 +65,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'birth_date' => 'date',
+            'last_login' => 'datetime',
         ];
     }
 

--- a/app/Service/Common/AuthService.php
+++ b/app/Service/Common/AuthService.php
@@ -3,6 +3,7 @@
 namespace App\Service\Common;
 
 use App\Enums\common\UserGuard;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
 class AuthService
@@ -19,6 +20,13 @@ class AuthService
     {
         if (!Auth::guard($guard)->attempt($data)) {
             return false;
+        }
+
+        // Update last login timestamp for user guard
+        if ($guard === UserGuard::USER->value) {
+            /** @var User $user */
+            $user = Auth::guard($guard)->user();
+            $user?->updateLastLogin();
         }
 
         return true;

--- a/app/Traits/TracksLastLogin.php
+++ b/app/Traits/TracksLastLogin.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Traits;
+
+use Carbon\Carbon;
+
+trait TracksLastLogin
+{
+    /**
+     * Update the user's last login timestamp.
+     *
+     * @return bool
+     */
+    public function updateLastLogin(): bool
+    {
+        return $this->update(['last_login' => now()]);
+    }
+
+    /**
+     * Update the user's last login timestamp with a custom timestamp.
+     *
+     * @param \Carbon\Carbon|null $timestamp
+     *
+     * @return bool
+     */
+    public function updateLastLoginAt(?Carbon $timestamp = null): bool
+    {
+        return $this->update(['last_login' => $timestamp ?? now()]);
+    }
+
+    /**
+     * Get the user's last login as a human readable format.
+     *
+     * @return string|null
+     */
+    public function getLastLoginForHumansAttribute(): ?string
+    {
+        return $this->last_login?->diffForHumans();
+    }
+
+    /**
+     * Check if the user has logged in today.
+     *
+     * @return bool
+     */
+    public function hasLoggedInToday(): bool
+    {
+        if (!$this->last_login) {
+            return false;
+        }
+
+        return $this->last_login->isToday();
+    }
+
+    /**
+     * Get the number of days since last login.
+     *
+     * @return int|null
+     */
+    public function daysSinceLastLogin(): ?int
+    {
+        if (!$this->last_login) {
+            return null;
+        }
+
+        return (int) $this->last_login->diffInDays(now());
+    }
+}

--- a/database/migrations/2025_01_27_120000_add_last_login_to_users_table.php
+++ b/database/migrations/2025_01_27_120000_add_last_login_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('last_login')->nullable()->after('email_verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_login');
+        });
+    }
+};


### PR DESCRIPTION
Add `TracksLastLogin` trait to track user last login times for reusability and clean separation of concerns.

The original request was about how to best implement a simple user last login update. A trait was chosen over a helper or service because it provides a lightweight, reusable solution directly on the `User` model, aligning with existing patterns in the codebase and keeping related functionality cohesive. It also includes helper methods for common login-related checks.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-4290348e-0fb1-42dd-bd5d-17654b0631cc) · [Cursor](https://cursor.com/background-agent?bcId=bc-4290348e-0fb1-42dd-bd5d-17654b0631cc)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)